### PR TITLE
Cambio reset formulario

### DIFF
--- a/src/main/resources/static/js/loadFiles.js
+++ b/src/main/resources/static/js/loadFiles.js
@@ -130,10 +130,14 @@ btSubmitOk.addEventListener("click", ()=> {
 });
 
 btSubmitError.addEventListener("click",()=> {
-    const dt = new DataTransfer();
+
     popup.style.display = "none";
     switchPopup(REMOVE_MSG_ERROR);
-    uploadFile.files = dt.files;
+    var name = fileName.value;
+    var selectedOption = fileType.selectedOptions[0].innerText;
+    form.reset();
+    fileName.value = name;
+    fileType.selectedOptions[0].innerText = selectedOption;
     deactivateFileName();
     submitController();
 });


### PR DESCRIPTION
Se elimina  `new DataTransfer()` y se reemplaza por simple código javascript para mantener los valores seleccionados
