### PR TITLE
Refact. y actualizacion colegio

### DIFF
--- a/src/main/java/com/react/pnld/mappers/SchoolMapper.java
+++ b/src/main/java/com/react/pnld/mappers/SchoolMapper.java
@@ -8,4 +8,6 @@ public interface SchoolMapper {
     School getSchoolByName(String name);
 
     int insertSchool(School school);
+
+    int updateSchool(School school);
 }

--- a/src/main/java/com/react/pnld/model/School.java
+++ b/src/main/java/com/react/pnld/model/School.java
@@ -7,6 +7,7 @@ public class School implements Serializable {
     private int id;
     private String name;
     private String city;
+    private String commune;
     private int regionId;
     private int rbd;
 
@@ -37,6 +38,10 @@ public class School implements Serializable {
     public void setCity(String city) {
         this.city = city;
     }
+
+    public String getCommune(){return commune;}
+
+    public void setCommune(String commune){this.commune = commune;}
 
     public int getRegionId() {
         return regionId;

--- a/src/main/java/com/react/pnld/repo/RegionRepository.java
+++ b/src/main/java/com/react/pnld/repo/RegionRepository.java
@@ -12,7 +12,7 @@ public class RegionRepository {
     @Autowired
     RegionMapper regionMapper;
 
-    public Optional<Integer> getRegionIdByName(String name) {
-        return Optional.ofNullable(regionMapper.getRegionIdByName(name));
+    public Integer getRegionIdByName(String name) {
+        return regionMapper.getRegionIdByName(name);
     }
 }

--- a/src/main/java/com/react/pnld/repo/SchoolRepository.java
+++ b/src/main/java/com/react/pnld/repo/SchoolRepository.java
@@ -28,4 +28,9 @@ public class SchoolRepository {
         logger.info("insertSchool. school={}", school);
         return schoolMapper.insertSchool(school);
     }
+
+    public int updateSchool(School school) {
+        logger.info("updateSchool. school={}", school);
+        return schoolMapper.updateSchool(school);
+    }
 }

--- a/src/main/java/com/react/pnld/services/EntityAttributeUtilService.java
+++ b/src/main/java/com/react/pnld/services/EntityAttributeUtilService.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 public class EntityAttributeUtilService {
 
-    public static final int RBD_ID_NOT_SPECIFIED = 0;
+
 
     public static String[] splitLastNames(String lastNames) {
 
@@ -31,9 +31,10 @@ public class EntityAttributeUtilService {
         return Normalizer.normalize(toClean, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "");
     }
 
-    public static int rbdToInt(String rbdStr) {
+    public static Integer rbdToInt(String rbdStr) { //TODO: Mejorar función
+        if(rbdStr == null || rbdStr.isEmpty()) return null;
         String cleanedRbd = rbdStr.replaceAll("[^\\d]", "");
-        if (cleanedRbd.isEmpty() || cleanedRbd.length() > 8) return RBD_ID_NOT_SPECIFIED;
+        if (cleanedRbd.isEmpty() || cleanedRbd.length() > 6) return null;
         return Integer.parseInt(cleanedRbd);
     }
 

--- a/src/main/java/com/react/pnld/services/LoaderMoodleFile.java
+++ b/src/main/java/com/react/pnld/services/LoaderMoodleFile.java
@@ -42,6 +42,9 @@ public class LoaderMoodleFile {
 
             School school = entityUtilService.getSchoolByName(postTrainingRow.getSchoolName());
 
+            if (school == null)
+                school = entityUtilService.createNewSchool(postTrainingRow.getSchoolName(), null, null, null, null);
+
             boolean rut = entityUtilService.validateTeacherByRut(postTrainingRow.getRut());
             boolean email = entityUtilService.validatePersonByEmail(postTrainingRow.getEmail());
 
@@ -94,6 +97,11 @@ public class LoaderMoodleFile {
         for (DiagnosticFileDTO diagnosticRow : diagnosticRows) {
 
             School school = entityUtilService.getSchoolByName(diagnosticRow.getSchoolName());
+
+            school = (school == null) ?
+                    entityUtilService.createNewSchool(diagnosticRow.getSchoolName(), null, diagnosticRow.getCommune(), diagnosticRow.getRegion(), diagnosticRow.getRbd())
+                    :
+                    entityUtilService.updateSchool(school, null, diagnosticRow.getCommune(), diagnosticRow.getRegion(), diagnosticRow.getRbd());
 
             boolean rut = entityUtilService.validateTeacherByRut(diagnosticRow.getRut());
             boolean email = entityUtilService.validatePersonByEmail(diagnosticRow.getEmail());
@@ -150,6 +158,9 @@ public class LoaderMoodleFile {
         for (SatisfactionFileDTO satisfactionRow : satisfactionRows) {
 
             School school = entityUtilService.getSchoolByName(satisfactionRow.getSchoolName());
+
+            if(school == null)
+                school = entityUtilService.createNewSchool(satisfactionRow.getSchoolName(), null, null, null, null);
 
             boolean rut = entityUtilService.validateTeacherByRut(satisfactionRow.getRut());
 

--- a/src/main/resources/maps.postgres/SchoolMapper.xml
+++ b/src/main/resources/maps.postgres/SchoolMapper.xml
@@ -8,14 +8,15 @@
         SELECT nextval(pg_get_serial_sequence('pnld.colegio', 'id'));
     </select>
 
-    <resultMap id="getSchoolByName" type="com.react.pnld.model.School">
+    <resultMap id="school" type="com.react.pnld.model.School">
         <id property="id" column="id"/>
         <result property="name" column="nombre" />
         <result property="city" column="ciudad" />
         <result property="regionId" column="id_region" />
         <result property="rbd" column="rbd" />
     </resultMap>
-    <select id="getSchoolByName" resultMap="getSchoolByName">
+
+    <select id="getSchoolByName" resultMap="school">
         SELECT *
         FROM pnld.colegio
         WHERE nombre = #{name};
@@ -23,9 +24,16 @@
 
     <insert id="insertSchool">
         INSERT INTO pnld.colegio
-            (id, id_region, nombre, ciudad, rbd)
+            (id, id_region, nombre, ciudad, comuna, rbd)
         VALUES
-            (#{id}, #{regionId}, #{name}, #{city}, #{rbd});
+            (#{id}, #{regionId}, #{name}, #{city}, #{commune}, #{rbd});
     </insert>
+
+    <update id="updateSchool">
+        UPDATE pnld.colegio
+        SET
+        ciudad = #{city}, comuna = #{commune}, id_region = #{regionId}, rbd = #{rbd}
+        WHERE id = #{id}
+    </update>
 
 </mapper>

--- a/src/test/java/com/react/pnld/FileUtilServiceTest.java
+++ b/src/test/java/com/react/pnld/FileUtilServiceTest.java
@@ -219,4 +219,18 @@ public class FileUtilServiceTest extends AbstractTestNGSpringContextTests {
         Assert.assertEquals(EntityAttributeUtilService.emailValidator(email3), false);
     }
 
+    @Test
+    public void rbdToInt(){
+        String rbdAsStr1 = "4045-9";
+        int rbdAsIntExpected1 = 40459;
+        Assert.assertEquals(EntityAttributeUtilService.rbdToInt(rbdAsStr1).intValue(), rbdAsIntExpected1);
+
+        String rbdAsStr2 = "22333-6";
+        int rbdAsIntExpected2 = 223336;
+        Assert.assertEquals(EntityAttributeUtilService.rbdToInt(rbdAsStr2).intValue(), rbdAsIntExpected2);
+
+        String rbdAsStr3 = "Municipal";
+        Assert.assertEquals(EntityAttributeUtilService.rbdToInt(rbdAsStr3), null);
+    }
+
 }


### PR DESCRIPTION
1. Adición de mapeo `update school` 
2.  Agrega función actualizar colegio solamente en procesamiento de archivo `cuestionario diagnostico` . Tanto para archivos de capacitación como de satisfacción no se agrega ya que estos sólo poseen el campo `nombre colegio` .
3. Modificación método `entityUtilService.getSchoolByName` . Se separa lógica de búsqueda por nombre y de creación de colegio.
4.  Creación método `entityUtilService.createNewSchool`