### PR TITLE
Feature posttest completed percentage service chart

### DIFF
--- a/src/main/resources/maps.postgres/TrainingIndicatorMapper.xml
+++ b/src/main/resources/maps.postgres/TrainingIndicatorMapper.xml
@@ -51,6 +51,8 @@
         <result property="notAssistanceCounter" column="no_asiste_jornada"/>
         <result property="preTestCompletedCounter" column="pre_test_completado"/>
         <result property="preTestNotCompletedCounter" column="pre_test_no_completado"/>
+        <result property="postTestCompletedCounter" column="post_test_completado"/>
+        <result property="postTestNotCompletedCounter" column="post_test_no_completado"/>
 
     </resultMap>
 
@@ -74,6 +76,8 @@
             COUNT(d.capacitacion_aprobada) FILTER(WHERE d.capacitacion_aprobada = false) AS capacitacion_reprobada,
             COUNT(tc.estado) FILTER(WHERE tc.estado = 'finalizado' AND tc.tipo = 'pre-capacita') AS pre_test_completado,
             COUNT(tc.estado) FILTER(WHERE tc.estado != 'finalizado' AND tc.tipo = 'pre-capacita') AS pre_test_no_completado,
+            COUNT(tc.estado) FILTER(WHERE tc.estado = 'finalizado' AND tc.tipo = 'post-capacita') AS post_test_completado,
+            COUNT(tc.estado) FILTER(WHERE tc.estado != 'finalizado' AND tc.tipo = 'post-capacita') AS post_test_completado,
             r.id AS id_region, r.nombre AS nombre_region
         FROM
             pnld.docente AS d

--- a/src/main/resources/static/css/header.css
+++ b/src/main/resources/static/css/header.css
@@ -1,5 +1,6 @@
 body{
     margin: 0;
+    font-family: Arial;
 }
 .header {
     display: flex;

--- a/src/main/resources/static/css/indicator/filter.css
+++ b/src/main/resources/static/css/indicator/filter.css
@@ -2,7 +2,7 @@
     border: 1px solid black;
     border-bottom: none;
     border-radius: 5px;
-    width: 240px;
+    width: 190px;
     overflow:hidden;
 }
 
@@ -19,7 +19,7 @@
     padding: 0em;
     overflow: hidden;
     transition: all .5s ease;
-    padding: 0 0 0 25px;
+    padding: 0 0 0 12px;
     text-align: initial;
 }
 

--- a/src/main/resources/static/css/indicator/filter.css
+++ b/src/main/resources/static/css/indicator/filter.css
@@ -26,7 +26,7 @@
 .filterAccordion .filterContent li{
     list-style: none;
     padding-top: 12px;
-
+    font-size: 14px;
 }
 
 .filterAccordion .filterContent li input[type=checkbox] {

--- a/src/main/resources/static/css/indicator/subdimension.css
+++ b/src/main/resources/static/css/indicator/subdimension.css
@@ -26,7 +26,7 @@
 .subDimensionAccordion .subDimensionContent li{
     list-style: none;
     padding-top: 12px;
-
+    font-size: 14px;
 }
 
 .subDimensionAccordion .subDimensionContent li a {

--- a/src/main/resources/static/css/indicator/subdimension.css
+++ b/src/main/resources/static/css/indicator/subdimension.css
@@ -2,7 +2,7 @@
     border: 1px solid black;
     border-bottom: none;
     border-radius: 5px;
-    width: 285px;
+    width: 270px;
     overflow:hidden;
 }
 
@@ -19,7 +19,7 @@
     padding: 0em;
     overflow: hidden;
     transition: all .5s ease;
-    padding: 0 0 0 25px;
+    padding: 0 0 0 12px;
     text-align: initial;
 }
 

--- a/src/main/resources/static/js/indicator/training/chart-setup.js
+++ b/src/main/resources/static/js/indicator/training/chart-setup.js
@@ -4,7 +4,7 @@ import {getSubDimensionSelected} from '../sub-dimension.js';
 import {getInstitutionSubDimensionData, getTeacherSubDimensionData} from './api.js';
 import {participantInstitutionCounter, firstTimeInstitutionPercentage} from './institution.js';
 import {trainedTeacherCounter, teacherInPersonSessionPercentage,
-        teacherPretestCompletedPercentage} from './teacher.js';
+        teacherPretestCompletedPercentage, teacherPostTestCompletedPercentage} from './teacher.js';
 
 const PARTICIPANT_INSTITUTION_NUMBER = 0;
 const FIRST_TIME_INSTITUTION_PERCENTAGE = 1;
@@ -76,7 +76,9 @@ async function selectChartByTeacher(chartOption){
     if(chartOption === PRE_TEST_COMPLETED_PERCENTAGE)
         teacherPretestCompletedPercentage(yearsSelected, dataList, labels);
 
-    if(chartOption === POST_TEST_COMPLETED_PERCENTAGE);
+    if(chartOption === POST_TEST_COMPLETED_PERCENTAGE)
+        teacherPostTestCompletedPercentage(yearsSelected, dataList, labels);
+
     if(chartOption === ONLINE_COURSE_COMPETED_PERCENTAGE);
     if(chartOption === TRAINING_COMPLETED_PERCENTAGE);
     if(chartOption === SCORE_DIFFERENCE_PRE_POST_TEST);

--- a/src/main/resources/static/js/indicator/training/chart.js
+++ b/src/main/resources/static/js/indicator/training/chart.js
@@ -54,7 +54,7 @@ export function participantInstitutionCounterChart (labels, datasets, title) {
                         label: function(data){
                             let value = data.formattedValue;
                             let label = data.dataset.label;
-                            return (value != 0) ? label + ": " + "cantidad " + value : null;
+                            return label + ": " + "cantidad " + value;
                         },
 
                       },
@@ -141,7 +141,7 @@ export function firstTimeInstitutionPercentageChart (labels, datasets, title, da
                       }).filter(e => typeof e != 'undefined');
                       let total = (typeof dataCounter[0] != 'undefined') ? dataCounter[0].total : 0;
                       let firstTimeCounter = (typeof dataCounter[0] != 'undefined') ? dataCounter[0].firstTime : 0;
-                      return (total != 0) ? "Detalle: " + "Total "+ total + " - valor actual " + firstTimeCounter : null;
+                      return "Detalle: " + "Total "+ total + " - valor actual " + firstTimeCounter;
                     },
                   },
               },
@@ -210,7 +210,7 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
                         label: function(data){
                             let value = data.formattedValue;
                             let label = data.dataset.label;
-                            return (value != 0) ? label + " " + keyword + ": " + "cantidad " + value : null;
+                            return label + " " + keyword + ": " + "cantidad " + value;
                         },
 
                       },

--- a/src/main/resources/static/js/indicator/training/chart.js
+++ b/src/main/resources/static/js/indicator/training/chart.js
@@ -1,10 +1,17 @@
 const ctx = document.getElementById('myChart').getContext('2d');
 var myChart;
 
+const PADDING_AXIS_TITLE = 12;
 const FONT_SIZE_AXIS_TITLE = 15;
 
 Chart.defaults.color = 'black';
 Chart.defaults.font.family = 'Arial';
+Chart.defaults.plugins.legend.position = 'right';
+Chart.defaults.plugins.legend.display = true;
+Chart.defaults.plugins.title.font.size = 25;
+Chart.defaults.plugins.title.display = true;
+Chart.defaults.plugins.tooltip.position = 'average';
+Chart.defaults.responsive = true;
 
 function defineTitle(data){
     return (data.length >= 2) ?
@@ -23,16 +30,13 @@ export function participantInstitutionCounterChart (labels, datasets, title) {
             options: {
                 scales: {
                     x: {
+                        position: 'top',
                         title: {
                             display: true,
                             text: 'Cantidad por región',
                             align: 'center',
-                            font: {
-                                size: 15,
-                            },
-                            padding: {
-                                top: 12,
-                            }
+                            font: { size: FONT_SIZE_AXIS_TITLE },
+                            padding: { bottom: PADDING_AXIS_TITLE }
                         }
                     },
                     y: {
@@ -40,12 +44,8 @@ export function participantInstitutionCounterChart (labels, datasets, title) {
                             display: true,
                             text: 'Regiones',
                             align: 'center',
-                            font: {
-                                size: 15,
-                            },
-                            padding: {
-                                bottom: 12,
-                            }
+                            font: { size: FONT_SIZE_AXIS_TITLE },
+                            padding: { bottom: PADDING_AXIS_TITLE }
                         }
                     }
                 },
@@ -65,15 +65,9 @@ export function participantInstitutionCounterChart (labels, datasets, title) {
                       },
                     },
                     title: {
-                        display: true,
                         text: 'Número de establecimientos que participan en PNLD ' + defineTitle(title),
-                    },
-                    legend: {
-                        display: true
                     }
-                },
-                responsive: true,
-
+                }
             }
         });
 
@@ -89,6 +83,7 @@ export function firstTimeInstitutionPercentageChart (labels, datasets, title, da
       options: {
           scales: {
               x: {
+                  position: 'top',
                   min: 0,
                   max: 100,
                   ticks:{
@@ -100,12 +95,8 @@ export function firstTimeInstitutionPercentageChart (labels, datasets, title, da
                       display: true,
                       text: 'Porcentaje participación por primera vez',
                       align: 'center',
-                      font: {
-                          size: 15,
-                      },
-                      padding: {
-                          top: 12,
-                      }
+                      font: { size: FONT_SIZE_AXIS_TITLE },
+                      padding: { bottom: PADDING_AXIS_TITLE },
                   }
               },
               y: {
@@ -113,9 +104,8 @@ export function firstTimeInstitutionPercentageChart (labels, datasets, title, da
                       display: true,
                       text: 'Regiones',
                       align: 'center',
-                      font: {
-                          size: 15,
-                      }
+                      font: { size: FONT_SIZE_AXIS_TITLE },
+                      padding: { bottom : PADDING_AXIS_TITLE }
                   }
               }
           },
@@ -151,15 +141,9 @@ export function firstTimeInstitutionPercentageChart (labels, datasets, title, da
                   },
               },
               title: {
-                  display: true,
                   text: 'Porcentaje de establecimientos que participan por primera vez ' + defineTitle(title),
-              },
-              legend: {
-                  display: true
               }
-          },
-          responsive: true,
-
+          }
       }
   });
 
@@ -169,7 +153,6 @@ export function firstTimeInstitutionPercentageChart (labels, datasets, title, da
 export function trainedTeacherCounterChart(labels, datasets, title, keyword){
 
     if(myChart) { myChart.destroy(); }
-//TOdO: Afecta a todos los gráficos
 
     myChart = new Chart(ctx, {
             type: 'bar',
@@ -185,13 +168,8 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
                             display: true,
                             text: 'Cantidad capacitados',
                             align: 'center',
-                            font: {
-                                size: FONT_SIZE_AXIS_TITLE,
-                            },
-                            padding: {
-                                top: 30,
-                                bottom: 12
-                            }
+                            font: { size: FONT_SIZE_AXIS_TITLE },
+                            padding: { bottom: PADDING_AXIS_TITLE },
                         }
                     },
                     y: {
@@ -199,12 +177,8 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
                             display: true,
                             text: 'Regiones',
                             align: 'center',
-                            font: {
-                                size: FONT_SIZE_AXIS_TITLE,
-                            },
-                            padding: {
-                                bottom: 12,
-                            }
+                            font: { size: FONT_SIZE_AXIS_TITLE },
+                            padding: { bottom: PADDING_AXIS_TITLE }
                         }
                     }
                 },
@@ -224,20 +198,9 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
                       },
                     },
                     title: {
-                        font:{
-                            size: 30,
-                            family: 'Arial',
-                        },
-                        display: true,
                         text: 'Número de docentes capacitados ' + defineTitle(title),
-                        padding: 20,
-                    },
-                    legend: {
-                        display: true,
                     }
                 },
-                responsive: true,
-
             }
         });
 
@@ -254,6 +217,7 @@ export function teacherInPersonSessionPercentageChart(labels, datasets, title, k
       options: {
           scales: {
               x: {
+                  position: 'top',
                   min: 0,
                   max: 100,
                   ticks:{
@@ -265,12 +229,8 @@ export function teacherInPersonSessionPercentageChart(labels, datasets, title, k
                       display: true,
                       text: 'Porcentaje asistencia jornada presencial',
                       align: 'center',
-                      font: {
-                          size: 15,
-                      },
-                      padding: {
-                          top: 12,
-                      }
+                      font: { size: FONT_SIZE_AXIS_TITLE },
+                      padding: { bottom: PADDING_AXIS_TITLE }
                   }
               },
               y: {
@@ -278,9 +238,8 @@ export function teacherInPersonSessionPercentageChart(labels, datasets, title, k
                       display: true,
                       text: 'Regiones',
                       align: 'center',
-                      font: {
-                          size: 15,
-                      }
+                      font: { size: FONT_SIZE_AXIS_TITLE },
+                      padding: { bottom: PADDING_AXIS_TITLE },
                   }
               }
           },
@@ -316,15 +275,9 @@ export function teacherInPersonSessionPercentageChart(labels, datasets, title, k
                   },
               },
               title: {
-                  display: true,
                   text: 'Porcentaje de docentes que asisten a jornada presencial ' + defineTitle(title),
-              },
-              legend: {
-                  display: true
               }
           },
-          responsive: true,
-
       }
   });
 
@@ -340,6 +293,7 @@ export function teacherPretestCompletedPercentageChart(labels, datasets, title, 
       options: {
           scales: {
               x: {
+                  position: 'top',
                   min: 0,
                   max: 100,
                   ticks:{
@@ -351,12 +305,8 @@ export function teacherPretestCompletedPercentageChart(labels, datasets, title, 
                       display: true,
                       text: 'Porcentaje pre-test completado',
                       align: 'center',
-                      font: {
-                          size: 15,
-                      },
-                      padding: {
-                          top: 12,
-                      }
+                      font: { size: FONT_SIZE_AXIS_TITLE },
+                      padding: { bottom: PADDING_AXIS_TITLE }
                   }
               },
               y: {
@@ -364,9 +314,8 @@ export function teacherPretestCompletedPercentageChart(labels, datasets, title, 
                       display: true,
                       text: 'Regiones',
                       align: 'center',
-                      font: {
-                          size: 15,
-                      }
+                      font: { size: FONT_SIZE_AXIS_TITLE },
+                      padding: { bottom: PADDING_AXIS_TITLE },
                   }
               }
           },
@@ -402,23 +351,15 @@ export function teacherPretestCompletedPercentageChart(labels, datasets, title, 
                   },
               },
               title: {
-                  display: true,
                   text: 'Porcentaje de docentes que completan pre-test ' + defineTitle(title),
-              },
-              legend: {
-                  display: true
               }
           },
-          responsive: true,
-
       }
   });
 
   myChart.update();
 }
 
-
-//TODO: Este se modifica
 export function teacherPostTestCompletedPercentageChart(labels, datasets, title, keyword, dataList){
   if(myChart) { myChart.destroy(); }
 
@@ -428,6 +369,7 @@ export function teacherPostTestCompletedPercentageChart(labels, datasets, title,
       options: {
           scales: {
               x: {
+                  position: 'top',
                   min: 0,
                   max: 100,
                   ticks:{
@@ -439,12 +381,8 @@ export function teacherPostTestCompletedPercentageChart(labels, datasets, title,
                       display: true,
                       text: 'Porcentaje post-test completado',
                       align: 'center',
-                      font: {
-                          size: FONT_SIZE_AXIS_TITLE, //TODO: ESTO PUEDE SER VARIABLE GLOBAL
-                      },
-                      padding: {
-                          top: 12, //TODO: ESTO PUEDE SER VARIABLE GLOBAL
-                      }
+                      font: { size: FONT_SIZE_AXIS_TITLE },
+                      padding: { bottom: PADDING_AXIS_TITLE },
                   }
               },
               y: {
@@ -452,9 +390,8 @@ export function teacherPostTestCompletedPercentageChart(labels, datasets, title,
                       display: true,
                       text: 'Regiones',
                       align: 'center',
-                      font: {
-                          size: FONT_SIZE_AXIS_TITLE,
-                      }
+                      font: { size: FONT_SIZE_AXIS_TITLE },
+                      padding: { bottom: PADDING_AXIS_TITLE },
                   }
               }
           },
@@ -490,12 +427,9 @@ export function teacherPostTestCompletedPercentageChart(labels, datasets, title,
                   },
               },
               title: {
-                  display: true,
                   text: 'Porcentaje de docentes que completan post-test ' + defineTitle(title),
               },
-              legend: { display: true }
           },
-          responsive: true,
       }
   });
 

--- a/src/main/resources/static/js/indicator/training/chart.js
+++ b/src/main/resources/static/js/indicator/training/chart.js
@@ -10,7 +10,6 @@ Chart.defaults.plugins.legend.position = 'right';
 Chart.defaults.plugins.legend.display = true;
 Chart.defaults.plugins.title.font.size = 25;
 Chart.defaults.plugins.title.display = true;
-Chart.defaults.plugins.tooltip.position = 'average';
 Chart.defaults.responsive = true;
 
 function defineTitle(data){

--- a/src/main/resources/static/js/indicator/training/chart.js
+++ b/src/main/resources/static/js/indicator/training/chart.js
@@ -1,6 +1,8 @@
 const ctx = document.getElementById('myChart').getContext('2d');
 var myChart;
 
+const FONT_SIZE_AXIS_TITLE = 15;
+
 Chart.defaults.color = 'black';
 Chart.defaults.font.family = 'Arial';
 
@@ -184,11 +186,11 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
                             text: 'Cantidad capacitados',
                             align: 'center',
                             font: {
-                                size: 15,
+                                size: FONT_SIZE_AXIS_TITLE,
                             },
                             padding: {
-                                top: 50,
-                                bottom: 50,
+                                top: 30,
+                                bottom: 12
                             }
                         }
                     },
@@ -198,7 +200,7 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
                             text: 'Regiones',
                             align: 'center',
                             font: {
-                                size: 15,
+                                size: FONT_SIZE_AXIS_TITLE,
                             },
                             padding: {
                                 bottom: 12,
@@ -223,12 +225,12 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
                     },
                     title: {
                         font:{
-                            size: 20,
+                            size: 30,
                             family: 'Arial',
                         },
                         display: true,
                         text: 'Número de docentes capacitados ' + defineTitle(title),
-                        padding: 50,
+                        padding: 20,
                     },
                     legend: {
                         display: true,
@@ -438,10 +440,10 @@ export function teacherPostTestCompletedPercentageChart(labels, datasets, title,
                       text: 'Porcentaje post-test completado',
                       align: 'center',
                       font: {
-                          size: 15,
+                          size: FONT_SIZE_AXIS_TITLE, //TODO: ESTO PUEDE SER VARIABLE GLOBAL
                       },
                       padding: {
-                          top: 12,
+                          top: 12, //TODO: ESTO PUEDE SER VARIABLE GLOBAL
                       }
                   }
               },
@@ -451,7 +453,7 @@ export function teacherPostTestCompletedPercentageChart(labels, datasets, title,
                       text: 'Regiones',
                       align: 'center',
                       font: {
-                          size: 15,
+                          size: FONT_SIZE_AXIS_TITLE,
                       }
                   }
               }
@@ -491,12 +493,9 @@ export function teacherPostTestCompletedPercentageChart(labels, datasets, title,
                   display: true,
                   text: 'Porcentaje de docentes que completan post-test ' + defineTitle(title),
               },
-              legend: {
-                  display: true
-              }
+              legend: { display: true }
           },
           responsive: true,
-
       }
   });
 

--- a/src/main/resources/static/js/indicator/training/chart.js
+++ b/src/main/resources/static/js/indicator/training/chart.js
@@ -1,6 +1,9 @@
 const ctx = document.getElementById('myChart').getContext('2d');
 var myChart;
 
+Chart.defaults.color = 'black';
+Chart.defaults.font.family = 'Arial';
+
 function defineTitle(data){
     return (data.length >= 2) ?
         data[data.length - 1] + " - " + data[0] : data[0];
@@ -164,6 +167,7 @@ export function firstTimeInstitutionPercentageChart (labels, datasets, title, da
 export function trainedTeacherCounterChart(labels, datasets, title, keyword){
 
     if(myChart) { myChart.destroy(); }
+//TOdO: Afecta a todos los gráficos
 
     myChart = new Chart(ctx, {
             type: 'bar',
@@ -174,6 +178,7 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
             options: {
                 scales: {
                     x: {
+                        position: 'top',
                         title: {
                             display: true,
                             text: 'Cantidad capacitados',
@@ -182,7 +187,8 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
                                 size: 15,
                             },
                             padding: {
-                                top: 12,
+                                top: 50,
+                                bottom: 50,
                             }
                         }
                     },
@@ -216,11 +222,16 @@ export function trainedTeacherCounterChart(labels, datasets, title, keyword){
                       },
                     },
                     title: {
+                        font:{
+                            size: 20,
+                            family: 'Arial',
+                        },
                         display: true,
                         text: 'Número de docentes capacitados ' + defineTitle(title),
+                        padding: 50,
                     },
                     legend: {
-                        display: true
+                        display: true,
                     }
                 },
                 responsive: true,

--- a/src/main/resources/static/js/indicator/training/chart.js
+++ b/src/main/resources/static/js/indicator/training/chart.js
@@ -403,3 +403,91 @@ export function teacherPretestCompletedPercentageChart(labels, datasets, title, 
 
   myChart.update();
 }
+
+
+//TODO: Este se modifica
+export function teacherPostTestCompletedPercentageChart(labels, datasets, title, keyword, dataList){
+  if(myChart) { myChart.destroy(); }
+
+  myChart = new Chart(ctx, {
+      type: 'bar',
+      data: { labels: labels, datasets: datasets },
+      options: {
+          scales: {
+              x: {
+                  min: 0,
+                  max: 100,
+                  ticks:{
+                    callback: function(value, index, values){
+                        return value+"%";
+                    }
+                  },
+                  title: {
+                      display: true,
+                      text: 'Porcentaje post-test completado',
+                      align: 'center',
+                      font: {
+                          size: 15,
+                      },
+                      padding: {
+                          top: 12,
+                      }
+                  }
+              },
+              y: {
+                  title: {
+                      display: true,
+                      text: 'Regiones',
+                      align: 'center',
+                      font: {
+                          size: 15,
+                      }
+                  }
+              }
+          },
+          indexAxis: 'y',
+          plugins:{
+              tooltip:{
+                  callbacks:{
+                    title: function(data){
+                      return data[0].label;
+                    },
+                    label: function(data){
+                        let percentage = data.formattedValue;
+                        let label = data.dataset.label;
+                        return label + " " + keyword + ": " + "Porcentaje " + percentage + "%" ;
+                    },
+                    afterLabel: function(data){
+                      let formattedValue = parseInt(data.formattedValue);
+                      let label = data.label;
+                      let datasetLabel = data.dataset.label;
+                      let regionData = dataList.find(element => element.regionName === label);
+                      let filterByYear = (typeof(keyword) === 'string') ? datasetLabel : keyword;
+                      let filterByGender = (typeof(keyword) === 'string') ? keyword : datasetLabel;
+
+                      let dataByYear = regionData.trainingIndicatorDataList.find(element => element.year === filterByYear);
+                      if(dataByYear === undefined) return "Detalle: " + "Total "+ 0 + " - " + "Valor actual " + formattedValue;;
+
+                      let dataByGender = dataByYear.dataByGenderList.find(element => element.gender === filterByGender.toLowerCase());
+                      if(dataByGender === undefined) return "Detalle: " + "Total "+ 0 + " - " + "Valor actual " + formattedValue;;
+
+                      let totalCompleted = dataByGender.postTestCompletedCounter + dataByGender.postTestNotCompletedCounter;
+                      return "Detalle: " + "Total "+ totalCompleted + " - " + "Valor actual " + dataByGender.postTestCompletedCounter;
+                    },
+                  },
+              },
+              title: {
+                  display: true,
+                  text: 'Porcentaje de docentes que completan post-test ' + defineTitle(title),
+              },
+              legend: {
+                  display: true
+              }
+          },
+          responsive: true,
+
+      }
+  });
+
+  myChart.update();
+}

--- a/src/main/resources/static/js/indicator/training/chart.js
+++ b/src/main/resources/static/js/indicator/training/chart.js
@@ -14,8 +14,10 @@ Chart.defaults.plugins.tooltip.position = 'average';
 Chart.defaults.responsive = true;
 
 function defineTitle(data){
-    return (data.length >= 2) ?
-        data[data.length - 1] + " - " + data[0] : data[0];
+    if(data === undefined) return '';
+
+    var titleSuffix = (data.length >= 2) ? data[data.length - 1] + " - " + data[0] : data[0];
+    return titleSuffix || '';
 }
 
 export function participantInstitutionCounterChart (labels, datasets, title) {

--- a/src/main/resources/static/js/indicator/training/teacher.js
+++ b/src/main/resources/static/js/indicator/training/teacher.js
@@ -101,7 +101,7 @@ export function teacherPretestCompletedPercentage(yearsSelected, dataList, label
 export function teacherPostTestCompletedPercentage(yearsSelected, dataList, labels){
     var datasets = [];
     var dataLoop = teacherDecisionLoop(yearsSelected);
-    console.log(dataList);
+
     dataLoop['list'].forEach( (element, i) => {
         var paletteColor = getPaletteColor(i);
         var data = [];
@@ -113,7 +113,6 @@ export function teacherPostTestCompletedPercentage(yearsSelected, dataList, labe
                 var trainingIndicatorDataList = getDataByParameter(e.trainingIndicatorDataList, filterYear);
                 var dataByGender = getDataByParameter(trainingIndicatorDataList.dataByGenderList, filterGender);
                 var completedPercentage = calculatePercentage(dataByGender.postTestCompletedCounter, dataByGender.postTestNotCompletedCounter);
-                console.log(completedPercentage);
                 data.push(completedPercentage);
             }
 
@@ -130,9 +129,7 @@ export function teacherPostTestCompletedPercentage(yearsSelected, dataList, labe
     teacherPostTestCompletedPercentageChart(labels, datasets, yearsSelected, dataLoop['data'], dataList);
 }
 
-
 //TODO: funcion general de porcentaje podria estar en otro arcvhio(?)
-//TODO: Se podría refactorizar con -> var1 || var2 las dos funciones de filtro
 function getDataByParameter(list, filterParameter){
     if(list === undefined) return {};
 
@@ -140,8 +137,7 @@ function getDataByParameter(list, filterParameter){
             if('year' in data) return data.year === filterParameter
             if('gender' in data) return data.gender === filterParameter;
         });
-
-    return (data != undefined) ? data : {};
+    return data || {};
 }
 
 //TODO: funcion general de porcentaje podria estar en otro arcvhio(?)

--- a/src/main/resources/static/js/indicator/training/teacher.js
+++ b/src/main/resources/static/js/indicator/training/teacher.js
@@ -1,5 +1,5 @@
 import {trainedTeacherCounterChart, teacherInPersonSessionPercentageChart,
-        teacherPretestCompletedPercentageChart} from './chart.js';
+        teacherPretestCompletedPercentageChart, teacherPostTestCompletedPercentageChart} from './chart.js';
 import {getPaletteColor, teacherDecisionLoop} from '../utils.js';
 
 const DECIMAL_NUMBER = 2;
@@ -117,6 +117,40 @@ export function teacherPretestCompletedPercentage(yearsSelected, dataList, label
     teacherPretestCompletedPercentageChart(labels, datasets, yearsSelected, dataLoop['data'], dataList);
 }
 
+export function teacherPostTestCompletedPercentage(yearsSelected, dataList, labels){
+    var datasets = [];
+    var dataLoop = teacherDecisionLoop(yearsSelected);
+    console.log(dataList);
+    dataLoop['list'].forEach( (element, i) => {
+        var paletteColor = getPaletteColor(i);
+        var data = [];
+        var filterGender = (dataLoop['filter']) ? element.toLowerCase() : dataLoop['data'];
+        var filterYear = (dataLoop['filter']) ? dataLoop['data'] : element;
+
+        dataList.forEach( (e,index) => {
+            if(labels.includes(e.regionName)){
+                var trainingIndicatorDataList = getDataByParameter(e.trainingIndicatorDataList, filterYear);
+                var dataByGender = getDataByParameter(trainingIndicatorDataList.dataByGenderList, filterGender);
+                var completedPercentage = calculatePercentage(dataByGender.postTestCompletedCounter, dataByGender.postTestNotCompletedCounter);
+                console.log(completedPercentage);
+                data.push(completedPercentage);
+            }
+
+        });
+
+        let dataset = {
+            'label': element,
+            'data': data,
+            'backgroundColor': paletteColor['backgroundColor'],
+            'borderColor': paletteColor['borderColor']
+        };
+        datasets.push(dataset);
+    });
+    teacherPostTestCompletedPercentageChart(labels, datasets, yearsSelected, dataLoop['data'], dataList);
+}
+
+
+//TODO: funcion general de porcentaje podria estar en otro arcvhio(?)
 function getDataByParameter(list, filterParameter){
     if(list === undefined) return {};
 
@@ -128,9 +162,12 @@ function getDataByParameter(list, filterParameter){
     return (data != undefined) ? data : {};
 }
 
+//TODO: funcion general de porcentaje podria estar en otro arcvhio(?)
 function calculatePercentage(favourableCase, notFavourableCase){
     if(favourableCase === undefined || notFavourableCase === undefined) return 0;
 
     var total = favourableCase + notFavourableCase;
+    if(total === 0) return total.toFixed(DECIMAL_NUMBER);
+
     return ((favourableCase / total) * 100).toFixed(DECIMAL_NUMBER);
 }

--- a/src/main/resources/static/js/indicator/training/teacher.js
+++ b/src/main/resources/static/js/indicator/training/teacher.js
@@ -16,16 +16,10 @@ export function trainedTeacherCounter(yearsSelected, dataList, labels ){
 
         dataList.forEach( (e,index) => {
             if(labels.includes(e.regionName)){
-                var approvedTrainingCounter = [0];
-                if(e.trainingIndicatorDataList != undefined && e.trainingIndicatorDataList.length != 0){
-                    let trainingIndicatorDataList = e.trainingIndicatorDataList.filter(data => data.year === filterYear);
-                    if(trainingIndicatorDataList != undefined && trainingIndicatorDataList.length != 0){
-                        approvedTrainingCounter = trainingIndicatorDataList[0].dataByGenderList.map(data => {
-                                if(data.gender === filterGender) return data.approvedTrainingCounter;
-                            }).filter(Boolean);
-                    }
-                }
-                data.push(approvedTrainingCounter[0]);
+                var trainingIndicatorDataList = getDataByParameter(e.trainingIndicatorDataList, filterYear);
+                var dataByGender = getDataByParameter(trainingIndicatorDataList.dataByGenderList, filterGender);
+                var approvedTrainingCounter = dataByGender.approvedTrainingCounter || 0;
+                data.push(approvedTrainingCounter);
             }
 
         });
@@ -54,24 +48,11 @@ export function teacherInPersonSessionPercentage(yearsSelected, dataList, labels
 
         dataList.forEach( (e,index) => {
             if(labels.includes(e.regionName)){
-                var inPersonSessionPercentage = [0];
-                var dataByGender = [];
-                if(e.trainingIndicatorDataList != undefined && e.trainingIndicatorDataList.length != 0){
-                    let trainingIndicatorDataList = e.trainingIndicatorDataList.filter(data => data.year === filterYear);
-                    if(trainingIndicatorDataList != undefined && trainingIndicatorDataList.length != 0){
-                        inPersonSessionPercentage = trainingIndicatorDataList[0].dataByGenderList.map(data => {
-                                if(data.gender === filterGender){
-                                    let totalAssistance = data.notAssistanceCounter + data.assistanceCounter;
-                                    let assistancePercentage = (data.assistanceCounter / totalAssistance) * 100;
-                                    return assistancePercentage.toFixed(DECIMAL_NUMBER);
-                                }
-                            }).filter(Boolean);
-                    }
-                }
-
-                data.push(inPersonSessionPercentage[0]);
+                var trainingIndicatorDataList = getDataByParameter(e.trainingIndicatorDataList, filterYear);
+                var dataByGender = getDataByParameter(trainingIndicatorDataList.dataByGenderList, filterGender);
+                var inPersonSessionPercentage = calculatePercentage(dataByGender.notAssistanceCounter, dataByGender.assistanceCounter);
+                data.push(inPersonSessionPercentage);
             }
-
         });
 
         let dataset = {
@@ -151,6 +132,7 @@ export function teacherPostTestCompletedPercentage(yearsSelected, dataList, labe
 
 
 //TODO: funcion general de porcentaje podria estar en otro arcvhio(?)
+//TODO: Se podría refactorizar con -> var1 || var2 las dos funciones de filtro
 function getDataByParameter(list, filterParameter){
     if(list === undefined) return {};
 
@@ -164,7 +146,8 @@ function getDataByParameter(list, filterParameter){
 
 //TODO: funcion general de porcentaje podria estar en otro arcvhio(?)
 function calculatePercentage(favourableCase, notFavourableCase){
-    if(favourableCase === undefined || notFavourableCase === undefined) return 0;
+    var notValue = 0;
+    if(favourableCase === undefined || notFavourableCase === undefined) return notValue.toFixed(DECIMAL_NUMBER);
 
     var total = favourableCase + notFavourableCase;
     if(total === 0) return total.toFixed(DECIMAL_NUMBER);

--- a/src/main/resources/static/js/indicator/training/teacher.js
+++ b/src/main/resources/static/js/indicator/training/teacher.js
@@ -126,10 +126,9 @@ export function teacherPostTestCompletedPercentage(yearsSelected, dataList, labe
         };
         datasets.push(dataset);
     });
-    teacherPostTestCompletedPercentageChart(labels, datasets, yearsSelected, dataLoop['data'], dataList);
+    teacherPostTestCompletedPercentageChart(labels, datasets, dataLoop['title'], dataLoop['data'], dataList);
 }
 
-//TODO: funcion general de porcentaje podria estar en otro arcvhio(?)
 function getDataByParameter(list, filterParameter){
     if(list === undefined) return {};
 
@@ -140,7 +139,6 @@ function getDataByParameter(list, filterParameter){
     return data || {};
 }
 
-//TODO: funcion general de porcentaje podria estar en otro arcvhio(?)
 function calculatePercentage(favourableCase, notFavourableCase){
     var notValue = 0;
     if(favourableCase === undefined || notFavourableCase === undefined) return notValue.toFixed(DECIMAL_NUMBER);

--- a/src/main/resources/static/js/indicator/utils.js
+++ b/src/main/resources/static/js/indicator/utils.js
@@ -83,10 +83,10 @@ export function activateDefaultsFilters(option){
 
 function getDataByLoop(option, yearsSelected, gendersSelected){
     if(option === true){
-        return { 'list': gendersSelected, 'data': yearsSelected[0], 'filter': true };
+        return { 'list': gendersSelected, 'data': yearsSelected[0], 'filter': true, title: yearsSelected};
     }
     if(option === false){
-        return {'list': yearsSelected, 'data': gendersSelected[0].toLowerCase(), 'filter': false};
+        return {'list': yearsSelected, 'data': gendersSelected[0].toLowerCase(), 'filter': false, title: gendersSelected};
     }
 }
 

--- a/src/main/resources/templates/indicators/indicator-base.ftlh
+++ b/src/main/resources/templates/indicators/indicator-base.ftlh
@@ -28,7 +28,7 @@
 
 <#macro chart >
     <div class=chartContainer id=chartContainer>
-        <canvas id="myChart" width="700" height="700"></canvas>
+        <canvas id="myChart" width="740" height="720"></canvas>
     </div>
 </#macro>
 


### PR DESCRIPTION
- Indicador N° 5 `Porcentaje de docentes que completan el post-test` integrado
- Cambio posición eje X general para todos los gráficos
- Leyendas de gráficos se posicionan a lado derecho (Arriba de gráficos se ve mucho espacio en blanco y se pierde parte del gráfico)
- Font-family Arial a nivel de proyecto
- Refactorización de código lado frontend
- Reajuste de espacio y tamaño de letra para subdimensiones, filtros y gráficos.
- Tooltip detallado para todos los gráficos
- Título de gráficos docentes ahora cambian entre género u año según los filtros a elegir
- Unificación de scripts en archivo` PR-35-script-datos-prueba` en este se detalla cuales comandos aplicar según indicador

Adjunto imágenes de indicador N° 5 

- Eligiendo un año
![image](https://user-images.githubusercontent.com/62573694/124986235-65ab8880-e009-11eb-9894-d2c7ee42e8c8.png)


- Eligiendo dos o más años
![image](https://user-images.githubusercontent.com/62573694/124986339-8378ed80-e009-11eb-90f7-04383205d0cf.png)


[POST EDIT]
- Imagen legendas posicionadas arriba de gráfico
![image](https://user-images.githubusercontent.com/62573694/124991770-161c8b00-e010-11eb-8359-a53a0a4de8ce.png)
